### PR TITLE
Fix: resource exhaustion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ INPUT     = android-dependencies-20170103T182209Z.tgz
 DEPS_URL  = https://github.com/measurement-kit/dependencies/releases/download/stable/$(INPUT)
 VERSION   = v0.4.0-beta.4
 BRANCH_OR_TAG = $(VERSION)
-OVERSION  = $(VERSION)-3
+OVERSION  = $(VERSION)-4
 OUTPUT    = measurement_kit_android-$(OVERSION).tar.bz2
 PACKAGE   = org.openobservatory.measurement_kit
 

--- a/jni/wrappers/ooni_test_wrapper_extra.cpp
+++ b/jni/wrappers/ooni_test_wrapper_extra.cpp
@@ -74,6 +74,8 @@ void OoniTestWrapper::on_progress(jobject delegate) {
             return;
         }
         environ->CallVoidMethod(global_cb, meth_id, jd, java_message);
+        environ->DeleteLocalRef(java_message);
+        environ->DeleteLocalRef(clazz);
     });
 }
 
@@ -105,6 +107,8 @@ void OoniTestWrapper::on_log(jobject delegate) {
         }
         environ->CallVoidMethod(global_cb, meth_id, java_severity,
                                 java_message);
+        environ->DeleteLocalRef(java_message);
+        environ->DeleteLocalRef(clazz);
     });
 }
 
@@ -134,6 +138,8 @@ void OoniTestWrapper::on_event(jobject delegate) {
             return;
         }
         environ->CallVoidMethod(global_cb, meth_id, java_message);
+        environ->DeleteLocalRef(java_message);
+        environ->DeleteLocalRef(clazz);
     });
 }
 
@@ -186,5 +192,7 @@ void OoniTestWrapper::on_entry(jobject delegate) {
             return;
         }
         environ->CallVoidMethod(global_cb, meth_id, java_entry);
+        environ->DeleteLocalRef(java_entry);
+        environ->DeleteLocalRef(clazz);
     });
 }

--- a/jni/wrappers/ooni_test_wrapper_extra.cpp
+++ b/jni/wrappers/ooni_test_wrapper_extra.cpp
@@ -66,11 +66,14 @@ void OoniTestWrapper::on_progress(jobject delegate) {
         }
         jclass clazz = environ->GetObjectClass(global_cb);
         if (!clazz) {
+            environ->DeleteLocalRef(java_message);
             return;
         }
         jmethodID meth_id = environ->GetMethodID(clazz, "callback",
                 "(DLjava/lang/String;)V");
         if (!meth_id) {
+            environ->DeleteLocalRef(java_message);
+            environ->DeleteLocalRef(clazz);
             return;
         }
         environ->CallVoidMethod(global_cb, meth_id, jd, java_message);
@@ -98,11 +101,14 @@ void OoniTestWrapper::on_log(jobject delegate) {
         }
         jclass clazz = environ->GetObjectClass(global_cb);
         if (!clazz) {
+            environ->DeleteLocalRef(java_message);
             return;
         }
         jmethodID meth_id = environ->GetMethodID(clazz, "callback",
                 "(JLjava/lang/String;)V");
         if (!meth_id) {
+            environ->DeleteLocalRef(java_message);
+            environ->DeleteLocalRef(clazz);
             return;
         }
         environ->CallVoidMethod(global_cb, meth_id, java_severity,
@@ -130,11 +136,14 @@ void OoniTestWrapper::on_event(jobject delegate) {
         }
         jclass clazz = environ->GetObjectClass(global_cb);
         if (!clazz) {
+            environ->DeleteLocalRef(java_message);
             return;
         }
         jmethodID meth_id = environ->GetMethodID(clazz, "callback",
                 "(Ljava/lang/String;)V");
         if (!meth_id) {
+            environ->DeleteLocalRef(java_message);
+            environ->DeleteLocalRef(clazz);
             return;
         }
         environ->CallVoidMethod(global_cb, meth_id, java_message);
@@ -184,11 +193,14 @@ void OoniTestWrapper::on_entry(jobject delegate) {
         }
         jclass clazz = environ->GetObjectClass(global_cb);
         if (!clazz) {
+            environ->DeleteLocalRef(java_entry);
             return;
         }
         jmethodID meth_id = environ->GetMethodID(clazz, "callback",
                 "(Ljava/lang/String;)V");
         if (!meth_id) {
+            environ->DeleteLocalRef(java_entry);
+            environ->DeleteLocalRef(clazz);
             return;
         }
         environ->CallVoidMethod(global_cb, meth_id, java_entry);


### PR DESCRIPTION
This completely addresses what we were supposed to address in #25. Basically, the problem in deac13f was that, when we run using `.run()`, we do not create a new environment but we attach to the existing one. However, in such patch, resources were cleaned *only* when we created a new environment, so it worked only for `.start()`. Another possible fix, rather than the diff in here, would have been to fix the destructor to *always* dispose of references.